### PR TITLE
hapi v17 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "graphql"
   ],
   "scripts": {
-    "test": "eslint src/"
+    "test": "npm-run-all test:jest test:lint",
+    "test:jest": "jest",
+    "test:lint": "eslint src/"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -30,8 +32,11 @@
     "eslint": "^4.18.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-jest": "^21.12.2",
     "graphql": "^0.13.1",
-    "hapi": "^17.2.0"
+    "hapi": "^17.2.0",
+    "jest": "^22.4.0",
+    "npm-run-all": "^4.1.2"
   },
   "dependencies": {
     "accepts": "^1.3.3",
@@ -47,6 +52,12 @@
     "parser": "babel-eslint",
     "extends": [
       "airbnb-base"
+    ],
+    "env": {
+      "jest/globals": true
+    },
+    "plugins": [
+      "jest"
     ]
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Create a GraphQL HTTP server with Hapi.",
   "author": "Simon Degraeve <simon.degraeve@gmail.com>",
-  "main": "./lib/index.js",
+  "main": "./src/index.js",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/SimonDegraeve/hapi-graphql/issues"
@@ -17,32 +17,31 @@
     "graphql"
   ],
   "scripts": {
-    "test": "eslint src",
-    "prepublish": "rm -rf lib/* && babel src --out-dir lib"
+    "test": "eslint src/"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
-    "babel-eslint": "^6.1.0",
+    "babel-eslint": "^8.2.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-2": "^6.11.0",
     "babel-runtime": "^6.9.2",
-    "eslint": "^3.0.1",
-    "eslint-config-airbnb-base": "^4.0.0",
-    "eslint-plugin-import": "^1.10.2",
-    "graphql": "^0.6.0",
-    "hapi": "^13.5.0"
+    "eslint": "^4.18.1",
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-plugin-import": "^2.9.0",
+    "graphql": "^0.13.1",
+    "hapi": "^17.2.0"
   },
   "dependencies": {
     "accepts": "^1.3.3",
     "babel-runtime": "^6.9.2",
-    "boom": "^3.2.2",
-    "joi": "^8.4.2"
+    "boom": "^7.1.1",
+    "joi": "^13.1.2"
   },
   "peerDependencies": {
     "babel-runtime": "^6.9.2",
-    "graphql": "^0.6.0"
+    "graphql": "^0.13.0"
   },
   "eslintConfig": {
     "parser": "babel-eslint",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "Simon Degraeve <simon.degraeve@gmail.com>",
   "main": "./src/index.js",
   "license": "MIT",
+  "engines": {
+    "node": ">= 8.9.0"
+  },
   "bugs": {
     "url": "https://github.com/SimonDegraeve/hapi-graphql/issues"
   },

--- a/package.json
+++ b/package.json
@@ -24,11 +24,6 @@
   "devDependencies": {
     "babel-cli": "^6.10.1",
     "babel-eslint": "^8.2.2",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-runtime": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-2": "^6.11.0",
-    "babel-runtime": "^6.9.2",
     "eslint": "^4.18.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.9.0",
@@ -40,12 +35,10 @@
   },
   "dependencies": {
     "accepts": "^1.3.3",
-    "babel-runtime": "^6.9.2",
     "boom": "^7.1.1",
     "joi": "^13.1.2"
   },
   "peerDependencies": {
-    "babel-runtime": "^6.9.2",
     "graphql": "^0.13.0"
   },
   "eslintConfig": {
@@ -58,16 +51,6 @@
     },
     "plugins": [
       "jest"
-    ]
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2"
-    ],
-    "plugins": [
-      "add-module-exports",
-      "transform-runtime"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "joi": "^13.1.2"
   },
   "peerDependencies": {
-    "graphql": "^0.13.0"
+    "graphql": "^0.13.0",
+    "hapi": "^17.2.0"
   },
   "eslintConfig": {
     "parser": "babel-eslint",

--- a/readme.md
+++ b/readme.md
@@ -7,22 +7,27 @@ Port from [express-graphql](https://github.com/graphql/express-graphql).
 npm install --save hapi-graphql
 ```
 
+If you are using `yarn`
+
+```js
+yarn add hapi-graphql
+```
+
 ### Example
 
 ```js
-import Hapi from 'hapi';
-import GraphQL from 'hapi-graphql';
-import {GraphQLSchema} from 'graphql';
+const Hapi = require('hapi');
+const GraphQL = require('hapi-graphql');
+const {GraphQLSchema} = require('graphql');
 
-const server = new Hapi.Server();
-server.connection({
+const server = new Hapi.Server({
   port: 3000
 });
 
 const TestSchema = new GraphQLSchema({});
 
-server.register({
-  register: GraphQL,
+await server.register({
+  plugin: GraphQL,
   options: {
     query: {
       # options, see below
@@ -37,11 +42,9 @@ server.register({
       config: {}
     }
   }
-}, () =>
-  server.start(() =>
-    console.log('Server running at:', server.info.uri)
-  )
-);
+});
+await server.start();
+console.log('Server running at:', server.info.uri);
 ```
 
 ### Options

--- a/src/index.js
+++ b/src/index.js
@@ -262,17 +262,15 @@ const handler = (route, options = {}) => async (request, h) => {
     // If allowed to show GraphiQL, present it instead of JSON.
     if (showGraphiQL) {
       return h
-        .response(
-          renderGraphiQL({
-            query, variables, operationName, result,
-          }))
+        .response(renderGraphiQL({
+          query, variables, operationName, result,
+        }))
         .type('text/html');
-    } else {
-      // Otherwise, present JSON directly.
-      return h
-        .response(JSON.stringify(result, null, pretty ? 2 : 0))
-        .type('application/json');
     }
+    // Otherwise, present JSON directly.
+    return h
+      .response(JSON.stringify(result, null, pretty ? 2 : 0))
+      .type('application/json');
   } catch (error) {
     // Return error, picking up Boom overrides
     const { statusCode = 500 } = error.output;

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const {
   getOperationAST,
   specifiedRules,
 } = require('graphql');
-const { version } = require('../package.json');
+const pkg = require('../package.json');
 const renderGraphiQL = require('./renderGraphiQL');
 const accepts = require('accepts');
 
@@ -311,7 +311,7 @@ const register = async (server, options = {}) => {
   const { route, query } = validation.value;
 
   // Register handler
-  server.handler('graphql', handler);
+  server.decorate('handler', 'graphql', handler);
 
   // Register route
   server.route({
@@ -326,7 +326,7 @@ const register = async (server, options = {}) => {
 
 const plugin = {
   register,
-  pkg: version,
+  pkg,
 };
 
 /**

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,5 +1,16 @@
 const hapi = require('hapi');
+const { buildSchema } = require('graphql');
+
 const plugin = require('./index');
+
+const schema = buildSchema(`
+type Query {
+  hello: String
+}
+`);
+const root = {
+  hello: () => 'Hello world!',
+};
 
 const hasRoute = (server, path, method) => {
   let foundRoute = false;
@@ -13,26 +24,78 @@ const hasRoute = (server, path, method) => {
   return foundRoute;
 };
 
-
-describe('hapi-graphql', () => {
+describe('plugin registration', () => {
   let server;
 
   beforeEach(() => {
     server = new hapi.Server({});
   });
-  it('registers cleanly into hapi v17+', async () => {
+  it('works with hapi v17+', async () => {
     await server.register({
       plugin,
       options: {
         route: {
           path: '/graphql',
           config: {
-
           },
         },
       },
     });
     expect(hasRoute(server, '/graphql', 'get')).toBeTruthy();
     expect(hasRoute(server, '/graphql', 'post')).toBeTruthy();
+  });
+});
+
+describe('query operations', () => {
+  let server;
+
+  beforeAll(async () => {
+    server = new hapi.Server({});
+    await server.register({
+      plugin,
+      options: {
+        query: {
+          schema,
+          rootValue: root,
+          formatError: error => ({
+            message: error.message,
+            locations: error.locations,
+            stack: error.stack,
+          }),
+        },
+        route: {
+          path: '/graphql',
+          config: {
+          },
+        },
+      },
+    });
+  });
+
+  it('responds to hello world queries', async () => {
+    const request = {
+      method: 'get',
+      url: '/graphql?query={ hello }',
+    };
+
+    const response = await server.inject(request);
+
+    expect(response.statusCode).toBe(200);
+    const payload = JSON.parse(response.payload);
+    expect(payload.data.hello).toBe('Hello world!');
+  });
+
+  it('complains on malformed queries', async () => {
+    const request = {
+      method: 'get',
+      url: '/graphql?query={ }',
+    };
+
+    const response = await server.inject(request);
+
+    expect(response.statusCode).toBe(400);
+    const payload = JSON.parse(response.payload);
+    expect(payload.errors).toHaveLength(1);
+    expect(payload.errors[0].message).toMatch(/Syntax Error/);
   });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,0 +1,38 @@
+const hapi = require('hapi');
+const plugin = require('./index');
+
+const hasRoute = (server, path, method) => {
+  let foundRoute = false;
+
+  server.table().forEach((route) => {
+    if (route.path === path && route.method.toLowerCase() === method.toLowerCase()) {
+      foundRoute = true;
+    }
+  });
+
+  return foundRoute;
+};
+
+
+describe('hapi-graphql', () => {
+  let server;
+
+  beforeEach(() => {
+    server = new hapi.Server({});
+  });
+  it('registers cleanly into hapi v17+', async () => {
+    await server.register({
+      plugin,
+      options: {
+        route: {
+          path: '/graphql',
+          config: {
+
+          },
+        },
+      },
+    });
+    expect(hasRoute(server, '/graphql', 'get')).toBeTruthy();
+    expect(hasRoute(server, '/graphql', 'post')).toBeTruthy();
+  });
+});

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -26,7 +26,7 @@ function safeSerialize(data) {
  * When shown, it will be pre-populated with the result of having executed the
  * requested query.
  */
-export default function renderGraphiQL(data) {
+module.exports = function renderGraphiQL(data) {
   const queryString = data.query;
   const variablesString =
     data.variables ? JSON.stringify(data.variables, null, 2) : null;
@@ -147,4 +147,4 @@ add "&raw" to the end of the URL within a browser.
   </script>
 </body>
 </html>`;
-}
+};

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -32,7 +32,7 @@ export default function renderGraphiQL(data) {
     data.variables ? JSON.stringify(data.variables, null, 2) : null;
   const resultString =
     data.result ? JSON.stringify(data.result, null, 2) : null;
-  const operationName = data.operationName;
+  const { operationName } = data;
 
   /* eslint-disable max-len */
   return `<!--


### PR DESCRIPTION
This PR moves the plugin to node v8 and hapi v17:

* completely removed babel (except for the eslint babel) as node 8 provides all the features built in (async / await + destructuring)
* all dependencies upgrade
* added unit-test using jest to show that:
    * the plugin can cleanly register with hapi v17
    * the graphql.org "hello world" schema works when registered via this plugin 
    * that the error handling on malformed queries is intact
* update code to comply with the new hapi v17 contracts