### PR TITLE
Fix error handling to properly return schema errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -273,6 +273,10 @@ const handler = (route, options = {}) => async (request, h) => {
       .type('application/json');
   } catch (error) {
     // Return error, picking up Boom overrides
+    if(!error.output) {
+      // ensure that there is a output object to avoid destructuring errors
+      error.output = {};
+    }
     const { statusCode = 500 } = error.output;
     const errors = error.data || [error];
     return h


### PR DESCRIPTION
And other errors where no "output" prop is added to the error object in
the catch handler.

Added test suite with purposefully broken schema to show that the error
now bubbles out of the error handler.

Closes #13 