### PR TITLE
Fix error handling on GraphQL schema initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -277,7 +277,7 @@ const handler = (route, options = {}) => async (request, h) => {
       // ensure that there is a output object to avoid destructuring errors
       error.output = {};
     }
-    const { statusCode = 500 } = error.output;
+    const { statusCode = 500 } = error.output || {};
     const errors = error.data || [error];
     return h
       .response({ errors: errors.map(errorFormatter) })


### PR DESCRIPTION
Fix common HTTP 500 Internal error if GraphQL failed to initialize schema due to declaratin errors. After this fix server will output readable error description (i.e. "The type of RootMutationType.addGood must be Output Type but got: undefined.").